### PR TITLE
Support more zlibrary config options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ webpack(webpackConfig, (err, stats) => {
 	}
 
 	// Build with zlib
-	if (pluginConfig.zlibrary) packed = zlibTemplate(packed, pluginConfig.meta, pluginConfig.changelog);
+	if (pluginConfig.zlibrary) packed = zlibTemplate(packed, pluginConfig);
 
 	// Add meta to packed file
 	const meta = `/**\n${Object.keys(pluginConfig.meta).reduce(

--- a/src/templates/zlibrary.js
+++ b/src/templates/zlibrary.js
@@ -1,8 +1,26 @@
-export default function zlibTemplate(packed, meta, changelog) {
+export default function zlibTemplate(packed, pluginConfig) {
+    meta = pluginConfig.meta;
+    info = pluginConfig.info;
+    changelog = pluginConfig.changelog;
+    defaultConfig = pluginConfig.defaultConfig;
+
+    if (!info) {
+        info = {
+            name: meta.name,
+            authors: [
+                {name: meta.author}
+            ],
+            version: meta.version,
+            description: meta.description,
+            github: meta.source,
+            github_raw: meta.updateUrl
+        };
+    }
+
 	return `
 /*@cc_on
 @if (@_jscript)
-    
+
     // Offer to self-install for clueless users that try to run this directly.
 	var shell = WScript.CreateObject("WScript.Shell");
 	var fs = new ActiveXObject("Scripting.FileSystemObject");
@@ -25,16 +43,9 @@ export default function zlibTemplate(packed, meta, changelog) {
 @else@*/
 
 const config = {
-    info: {
-        name: "${meta.name}",
-        authors: [{
-            name: "${meta.author}",
-        }],
-        version: "${meta.version}",
-        description: "${meta.description}",
-        github: "${meta.source}",
-        github_raw: "${meta.updateUrl}"
-    }${changelog ? `, changelog: ${JSON.stringify(changelog).replace(/"([^"]+)":/g, "$1:")}` : ""}
+    info: ${JSON.stringify(info).replace(/"([^"]+)":/g, "$1:")}
+    ${changelog ? `, changelog: ${JSON.stringify(changelog).replace(/"([^"]+)":/g, "$1:")}` : ""}
+    ${defaultConfig ? `, defaultConfig: ${JSON.stringify(defaultConfig).replace(/"([^"]+)":/g, "$1:")}` : ""}
 };
 
 if (!global.ZeresPluginLibrary) {


### PR DESCRIPTION
The `meta` configuration is not as powerful as `zlibrary`'s `info` section.

Also, BundleBD currently seems to ignore the `defaultConfig` section.

This PR fixes the two issues by:
- Only guessing values from `meta` if an `info` section is not present.
- Supporting `defaultConfig`.